### PR TITLE
Adding email notification option to allo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By default, [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh) is used.
 | :---- | :---- |
 | `cuda*` | switch cuda version |
 | `g2top` | display gpu/cpu/mem availability |
-| `allo [--cpu $Ncpus] [--gpu $Ngpus] [--mem $Ngb] [--time $Ndays] [--node $nodename] [--p $partition]` | submit new job |
+| `allo [--cpu $Ncpus] [--gpu $Ngpus] [--mem $Ngb] [--time $Ndays] [--node $nodename] [--p $partition] [--email $email]` | submit new job |
 | `sq [-v]` | display your jobs |
 | `wn` | monitor gpu status |
 | `kq` | show running jobs in `kilian` queue |

--- a/bin/allo.py
+++ b/bin/allo.py
@@ -17,6 +17,7 @@ parser.add_argument('--mem', type=int, default=64)
 parser.add_argument('--time', type=int, default=14)
 parser.add_argument('--node', type=str, default=None)
 parser.add_argument('--p', type=str, default="default_partition")
+parser.add_argument('--email', type=str, default=None, help="Email address to send notification of job state changes.")
 args = parser.parse_args()
 port = random.randint(32133, 53112)
 node="""#!/bin/bash
@@ -34,6 +35,9 @@ if args.time is not None:
     node += f"#SBATCH -t {args.time}                                          # Run time (hh:mm:ss)\n"
 if args.node is not None:
     node += "#SBATCH --nodelist={}\n".format(args.node)
+if args.email is not None:
+    node += "#SBATCH --mail-type=ALL\n"
+    node += f"#SBATCH --mail-user={args.email}\n"
 
 node += """cd $HOME
 export XDG_RUNTIME_DIR=""


### PR DESCRIPTION
First off, thanks so much for creating this repo - it's super helpful! 

I thought it could be helpful to add an email notification option to `allo.py`, mainly so I can tell if my jobs get pre-empted via email without having to check g2 directly. If you feel it'd be useful, feel free to add this PR to the repo!